### PR TITLE
Avoid Deprecated warning when sending message

### DIFF
--- a/src/Messages/SendMessageCommand.php
+++ b/src/Messages/SendMessageCommand.php
@@ -19,7 +19,7 @@ class SendMessageCommand
      * @param Model        $sender       The sender identifier
      * @param string       $type         The message type
      */
-    public function __construct(Conversation $conversation, $body, Model $sender, $type = 'text', $data)
+    public function __construct(Conversation $conversation, $body, Model $sender, $type = 'text', $data=null)
     {
         $this->conversation = $conversation;
         $this->body = $body;


### PR DESCRIPTION
Fix error when sending a message like this
```
$message = Chat::message('Hello')     
  ->from($user)
            ->to($conversation)
            ->send();
```

```PHP Deprecated:  Required parameter $data follows optional parameter $type in /Users/christophe/development/RDV.biz/vendor/musonza/chat/src/Messages/SendMessageCommand.php on line 22```